### PR TITLE
Trigger Helm chart release on merged PRs and auto bump chart version

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -1,17 +1,59 @@
 name: Release Helm Chart
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+    types:
+      - closed
   workflow_dispatch:
 
 jobs:
   lint-and-release:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    env:
+      TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+      MERGE_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.MERGE_COMMIT }}
+          fetch-depth: 0
+
+      - name: Prepare repository
+        run: |
+          git fetch origin "$TARGET_BRANCH"
+          git checkout "$TARGET_BRANCH"
+          git pull --ff-only origin "$TARGET_BRANCH"
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump chart version
+        id: bump_version
+        run: |
+          chart_file="charts/paperless-ngx/Chart.yaml"
+          current_version=$(grep '^version:' "$chart_file" | awk '{print $2}')
+          IFS='.' read -r major minor patch <<<"$current_version"
+          if [ -z "$major" ] || [ -z "$minor" ] || [ -z "$patch" ]; then
+            echo "Unable to parse current chart version: $current_version" >&2
+            exit 1
+          fi
+          if ! [[ $patch =~ ^[0-9]+$ ]]; then
+            echo "Chart patch version must be numeric, found: $patch" >&2
+            exit 1
+          fi
+          new_patch=$((patch + 1))
+          new_version="${major}.${minor}.${new_patch}"
+          sed -i "s/^version: .*/version: ${new_version}/" "$chart_file"
+          git add "$chart_file"
+          git commit -m "chore: bump chart version to ${new_version}"
+          git push origin "HEAD:${TARGET_BRANCH}"
+          echo "version=${new_version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
## Summary
- run the release workflow when pull requests into main are merged or when manually dispatched
- automatically bump the chart version by committing the patched Chart.yaml before running chart releaser

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e4cab24898832da3188ccdf47e0000