### PR TITLE
Fix release workflow permissions for chart releases

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -9,6 +9,10 @@ on:
       - closed
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   lint-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant the release workflow explicit write access so the version bump push succeeds

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4cccc1208832d991954af35fc3e4c