### PR TITLE
Fix Helm service templates missing end delimiters

### DIFF
--- a/charts/paperless-ngx/templates/gotenberg-service.yaml
+++ b/charts/paperless-ngx/templates/gotenberg-service.yaml
@@ -14,3 +14,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "paperless-ngx.name" . }}-gotenberg
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/paperless-ngx/templates/postgresql-service.yaml
+++ b/charts/paperless-ngx/templates/postgresql-service.yaml
@@ -14,3 +14,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "paperless-ngx.name" . }}-postgresql
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/paperless-ngx/templates/redis-service.yaml
+++ b/charts/paperless-ngx/templates/redis-service.yaml
@@ -14,3 +14,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "paperless-ngx.name" . }}-redis
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/paperless-ngx/templates/tika-service.yaml
+++ b/charts/paperless-ngx/templates/tika-service.yaml
@@ -14,3 +14,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "paperless-ngx.name" . }}-tika
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
## Summary
- add the missing `{{- end }}` delimiters to the optional service templates so `helm lint` can render them successfully

## Testing
- helm lint charts/paperless-ngx *(fails locally: helm is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cec36a7c832db3f13b922094758e